### PR TITLE
added customer key to book objects

### DIFF
--- a/js/bookBuilder.js
+++ b/js/bookBuilder.js
@@ -32,6 +32,11 @@ const bookBuilder = (title, author, genre, isbn, photoSrc) => {
             "photoSrc": {
                 value: photoSrc,
                 enumerable: true,
+            },
+            "customer": {
+                value: "",
+                writable: true,
+                enumerable: true
             }
         })
     )


### PR DESCRIPTION
added a key to the function which creates the book objects with key name of 'customer' and default value "". 

```
git fetch --all
git checkout RM_add_location_to_book_objects
```

1. check edits to function in bookBuilder.js
1. load page and run 'Library' in console. objects should now have customer key with value "".